### PR TITLE
Some minor improvements for commit 9c30ae3

### DIFF
--- a/pygeoapi/api.py
+++ b/pygeoapi/api.py
@@ -1600,7 +1600,7 @@ class API:
         query_args = {}
         format_ = F_JSON
 
-        # Force content type and language (en-US only) headers
+        # Force response content type and language (en-US only) headers
         headers = request.get_response_headers(SYSTEM_LOCALE,
                                                FORMAT_TYPES[F_JSON])
 
@@ -1653,7 +1653,8 @@ class API:
 
         query_args['datetime_'] = datetime_
 
-        if request.format:
+        if 'f' in request.params:
+            # Format explicitly set using a query parameter
             query_args['format_'] = format_ = request.format
 
         range_subset = request.params.get('rangeSubset')
@@ -1714,14 +1715,7 @@ class API:
                 500, headers, format_, 'NoApplicableCode', msg)
 
         mt = collection_def['format']['name']
-        coverage_format = request.params.get('f')
-
-        is_native_format = any([
-            coverage_format is None,
-            coverage_format == mt
-        ])
-
-        if is_native_format:  # native format
+        if format_ == mt:  # native format
             headers['Content-Type'] = collection_def['format']['mimetype']
             return headers, 200, data
         elif format_ == F_JSON:
@@ -2857,14 +2851,8 @@ class API:
         # Content-Language is in the system locale (ignore language settings)
         headers = request.get_response_headers(SYSTEM_LOCALE)
         msg = f'Invalid format: {request.format}'
-
-        if headers['Content-Type'] == 'text/html':
-            format_ = F_HTML
-        else:
-            format_ = F_JSON
-
         return self.get_exception(
-            400, headers, format_, 'InvalidParameterValue', msg)
+            400, headers, request.format, 'InvalidParameterValue', msg)
 
 
 def validate_bbox(value=None) -> list:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -230,7 +230,7 @@ def test_api(config, api_, openapi):
     assert api_.config == config
     assert isinstance(api_.config, dict)
 
-    req = mock_request(HTTP_CONTENT_TYPE='application/json')
+    req = mock_request(HTTP_ACCEPT='application/json')
     rsp_headers, code, response = api_.openapi(req, openapi)
     assert rsp_headers['Content-Type'] == 'application/vnd.oai.openapi+json;version=3.0'  # noqa
     # No language requested: should be set to default from YAML
@@ -864,6 +864,13 @@ def test_get_collection_coverage(config, api_):
 
     assert code == 400
     assert rsp_headers['Content-Type'] == 'text/html'
+
+    req = mock_request(HTTP_ACCEPT='text/html')
+    rsp_headers, code, response = api_.get_collection_coverage(
+        req, 'gdps-temperature')
+
+    assert code == 200
+    assert rsp_headers['Content-Type'] == 'application/prs.coverage+json'
 
     req = mock_request({'subset': 'Lat(5:10),Long(5:10)'})
     rsp_headers, code, response = api_.get_collection_coverage(


### PR DESCRIPTION
Also added an important test to ensure that having _no_ `f` query parameter, but an `Accept` header set to `text/html` returns JSON and does not throw an error. Which was the issue [here](https://github.com/geopython/pygeoapi/issues/705#issuecomment-858428805).